### PR TITLE
GCI-32: Site header and session status revamp

### DIFF
--- a/app/system-modules/auth/views/login.ejs
+++ b/app/system-modules/auth/views/login.ejs
@@ -1,7 +1,6 @@
 <% name = 'login' %>
 <% title = 'OpenMRS ID - Login' %>
 <% headline = 'Login with your OpenMRS ID' %>
-<% sidebar.unshift('sidebar/id-whatis') %>
 
 <form action="/login" method="post">
 	<p><em></em></p>

--- a/app/system-modules/signup/views/signup.ejs
+++ b/app/system-modules/signup/views/signup.ejs
@@ -1,7 +1,7 @@
 <% name = 'signup' %>
 <% title = 'OpenMRS ID - Sign Up' %>
 <% headline = 'Get an OpenMRS ID' %>
-<% sidebar = ['sidebar/id-whatis', 'sidebar/forgotpassword'] %>
+<% sidebar = ['sidebar/forgotpassword'] %>
 
 <% headAppend += '<script src="/signup/resource/md5.js"></script>\n' %>
 <% headAppend += '<script src="/signup/resource/signup-public.js"></script>\n' %>

--- a/views/layouts/header/top.ejs
+++ b/views/layouts/header/top.ejs
@@ -1,6 +1,6 @@
 <div id="header" class="clearfix"> 
   <div class="container">
-    <header class="col-md-8 col-md-offset-1 col-sm-10">
+    <header class="<%= (!connected) ? 'col-md-5' : 'col-md-8' %> col-md-offset-1 col-sm-10 col-xs-10">
       <a href="/">
         <img id="logo" src="/resource/images/logo.png" alt="OpenMRS Community">
       </a>

--- a/views/layouts/header/top.ejs
+++ b/views/layouts/header/top.ejs
@@ -1,6 +1,6 @@
 <div id="header" class="clearfix"> 
   <div class="container">
-    <header class="<%= (!connected) ? 'col-md-5' : 'col-md-8' %> col-md-offset-1 col-sm-10 col-xs-10">
+    <header class="<%= (!connected) ? 'col-md-5' : 'col-md-6' %> col-md-offset-1 col-sm-10 col-xs-10">
       <a href="/">
         <img id="logo" src="/resource/images/logo.png" alt="OpenMRS Community">
       </a>

--- a/views/layouts/headline.ejs
+++ b/views/layouts/headline.ejs
@@ -1,9 +1,5 @@
 <div id="headline" class="<% if (showHeadlineAvatar) { %> with-avatar<% } %>">
   <div class="container">
-    <h1 class="col-md-8 col-md-offset-1"><%- headline %>
-  <% if (connected && showHeadlineAvatar) { %>
-    <img src="https://wiki.openmrs.org/rest/cas/1.0/avatar/server/<%= mailHash %>?s=51" alt="<%= user.displayName %>">
-    <% } %>
-    </h1>
+    <h1 class="col-md-8 col-md-offset-1"><%- headline %></h1>
   </div>
 </div>

--- a/views/layouts/login-menu.ejs
+++ b/views/layouts/login-menu.ejs
@@ -2,7 +2,7 @@
 <div id="login-menu" class="col-sm-10 col-xs-10 col-md-5">
 <% } %>
 <% if (connected) { %>
-<div id="login-menu" class="col-sm-2">
+<div id="login-menu" class="col-sm-4">
 <% } %>
 
   <% if (!connected) { %>
@@ -10,12 +10,13 @@
   <% } %>
 
   <% if (connected) { %>
-    <div class="dropdown">
-      <a href="#" data-toggle="dropdown" class="btn btn-primary"><%= user.displayName %></a>
-      <ul class="dropdown-menu">
-        <li><a href="/profile">View Your Profile</a></li>
-        <li><a href="/disconnect">Log Out</a></li>
-      </ul>
+    <div class="col-md-10" style="text-align:right">
+        <strong>Welcome, <%= user.displayName %></strong>
+        </br>
+        <a href="/disconnect">Log Out</a>
+    </div>
+    <div class="col-sm-2">
+        <img src="https://wiki.openmrs.org/rest/cas/1.0/avatar/server/<%= mailHash %>?s=51" alt="<%= user.displayName %>">
     </div>
   <% } %>
 </div>

--- a/views/layouts/login-menu.ejs
+++ b/views/layouts/login-menu.ejs
@@ -1,25 +1,12 @@
+<% if (!connected) { %>
+<div id="login-menu" class="col-sm-10 col-xs-10 col-md-5">
+<% } %>
+<% if (connected) { %>
 <div id="login-menu" class="col-sm-2">
-  <% if (!connected) { %>
-    <button class="btn btn-primary" data-toggle="popover" data-placement="bottom" data-content-id="login-form">Log In</button>
+<% } %>
 
-    <script type="text/html" data-target="popover" data-content-id="login-form">
-    <form action="/login" method="post">
-      <div class="form-group">
-        <label for="loginusername">OpenMRS ID</label>
-        <input class="use-placeholder" type="text" placeholder="OpenMRS ID" name="loginusername">
-      </div>
-      <div class="form-group">
-        <label for="loginpassword">Password</label>
-        <input class="use-placeholder" type="password" placeholder="Password" name="loginpassword">
-      </div>
-      <div class="form-group">
-        <span class="failtext">Authentication failed.
-        <a href="/reset">Password Recovery &#187;</a></span>
-      </div>
-      <input type="submit" class="btn btn-primary btn-sm" value="Log In &#187;">
-    </form>
-    </script>
-    <div class="popover-direction" data-popid="login"></div>
+  <% if (!connected) { %>
+    <p>Your OpenMRS ID is the key to participating in our open source community. Use it to access all of the tools and services listed on the links at the top of this page. <a href="http://go.openmrs.org/id">Read more on our Wiki.</a></p>
   <% } %>
 
   <% if (connected) { %>

--- a/views/sidebar/id-whatis.ejs
+++ b/views/sidebar/id-whatis.ejs
@@ -1,3 +1,0 @@
-<h2>What is OpenMRS ID?</h2>
-<p>OpenMRS ID is your key to participating in our open source community. You can use it for most of our tools and services, including those listed in the links at the top of this page.
-<a href="http://go.openmrs.org/id"><strong>Read more on our wiki.</strong></a></p>

--- a/views/template.ejs
+++ b/views/template.ejs
@@ -4,11 +4,7 @@
 
 <!-- Optional Paramaters: -->
 <% title = 'OpenMRS ID - Template' /* <title> in the user's browser, defaults to the site name */ %>
-<% sidebar = ['sidebar/id-whatis] /* Array of extra sidebar pages. Relative to the global /views directory. (pass __dirname to easily use paths relative to a module) */ %>
-<% sidebarParams['sidebar/id-whatis'] = /* Extended sidebar options, named with same pathname as the sidebar page */ {
-		className: 'box', /* Extra classes to give this sidebar page */
-		locals: {} /* Extra variabled to pass to this sidebar page */
-} %>
+<% sidebar = [] /* Array of extra sidebar pages. Relative to the global /views directory. (pass __dirname to easily use paths relative to a module) */ %>
 <% showHeadlineAvatar = false /* Show avatar in heading, defaults to true */ %>
 
 <h2>Highest heading level you should use.</h2>


### PR DESCRIPTION
Implement [GCI-32](https://issues.openmrs.org/browse/GCI-32) / [ID-69](https://issues.openmrs.org/browse/ID-69) ([Melange task](https://www.google-melange.com/gci/task/view/google/gci2014/5317001035644928)), revamping the site header. It now shows a blurb instead of a login button when there isn't an active session, and shows the profile image, username, and a logout button if there is an active session.
