### PR TITLE
GCI-41: edit basic account details widget

### DIFF
--- a/app/system-modules/profile/views/edit-basic-details.ejs
+++ b/app/system-modules/profile/views/edit-basic-details.ejs
@@ -1,0 +1,37 @@
+<div class="list-group">
+    <div class="list-group-item">
+
+        <form action="/profile" method="post">
+
+            <div class="field noedit">
+                <p class="h3"><%= user.username %> <small>Username</small></p>
+            </div>
+
+            <div class="field two-up<% if (fail.firstName || fail.lastName ) {
+                %> fail<% } %>">
+                <p><label>Name</label></p>
+                <input type="text" name="firstName" placeholder="Given Name" value="<%= (failed) ? values.firstName : user.firstName %>">
+                <input type="text" name="lastName" placeholder="Surname" value="<%= (failed) ? values.lastName : user.lastName %>">
+                <span class="description">
+                    <span class="failtext">Both a first and last name are required.</span>
+                    Your name identifies you across the OpenMRS Community.
+                </span>
+            </div>
+
+            <div class="field">
+                <input class="btn btn-success" type="submit" value="Update Profile &#187;">
+            </div>
+        </form>
+
+        <hr>
+
+        <h2>Your profile picture</h2>
+        <p>Profile pictures are managed along with your profile on the OpenMRS Wiki. Head over to Confluence to <a href="https://wiki.openmrs.org/users/viewmyprofile.action" target="_blank">edit your Wiki profile</a> or <a href="https://wiki.openmrs.org/users/editmyprofilepicture.action" target="_blank">change your profile picture</a>.</p>
+
+        <hr>
+
+        <h2><a href="#">Need to change your password?</a></h2>
+        <% include edit-password %>
+
+    </div>
+</div>

--- a/app/system-modules/profile/views/edit-basic-details.ejs
+++ b/app/system-modules/profile/views/edit-basic-details.ejs
@@ -1,26 +1,30 @@
-<div class="list-group">
+<div class="list-group col-md-6">
     <div class="list-group-item">
+        <h1><%= user.username %> <small>username</small></h1>
 
         <form action="/profile" method="post">
-
-            <div class="field noedit">
-                <p class="h3"><%= user.username %> <small>Username</small></p>
+          <div class="form-group<% if (fail.firstName || fail.lastName ) {
+                      %> fail<% } %>">
+            <label>Name</label>
+            <div class="row">
+              <div class="col-md-6">
+                <input type="text" name="firstName" placeholder="Given Name" value="<%= (failed) ? values.firstName : user.firstName %>" class="form-control">
+              </div>
+              <div class="col-md-6">
+                <input type="text" name="lastName" placeholder="Surname" value="<%= (failed) ? values.lastName : user.lastName %>" class="form-control">
+              </div>
             </div>
-
-            <div class="field two-up<% if (fail.firstName || fail.lastName ) {
-                %> fail<% } %>">
-                <p><label>Name</label></p>
-                <input type="text" name="firstName" placeholder="Given Name" value="<%= (failed) ? values.firstName : user.firstName %>">
-                <input type="text" name="lastName" placeholder="Surname" value="<%= (failed) ? values.lastName : user.lastName %>">
-                <span class="description">
-                    <span class="failtext">Both a first and last name are required.</span>
-                    Your name identifies you across the OpenMRS Community.
-                </span>
+            <span class="help-block description">
+              <span class="failtext">Both a first and last name are required.</span>
+              Your name identifies you across the OpenMRS Community.
+            </span>
+          </div>
+          <div class="row">
+            <div class="col-md-12">
+              <input class="btn btn-success pull-right" type="submit" value="Update Profile &#187;">
             </div>
-
-            <div class="field">
-                <input class="btn btn-success" type="submit" value="Update Profile &#187;">
-            </div>
+          </div>
+              
         </form>
 
         <hr>
@@ -30,7 +34,7 @@
 
         <hr>
 
-        <h2><a href="#">Need to change your password?</a></h2>
+        <h2><a href="#" id="editPasswordToggle">Need to change your password?</a></h2>
         <% include edit-password %>
 
     </div>

--- a/app/system-modules/profile/views/edit-password.ejs
+++ b/app/system-modules/profile/views/edit-password.ejs
@@ -1,32 +1,40 @@
-<form action="/password" method="post">
-	<div class="field<% if (fail.currentpassword) { %> fail<% } %>">
-		<label>Current Password</label>
-		<input type="password" name="currentpassword" placeholder="Current Password">
-		<span class="description">
+<form action="/password" method="post" class="form-horizontal" id="editPassword">
+	<div class="form-group<% if (fail.currentpassword) { %> fail<% } %>">
+		<label for="currentpassword" class="col-md-6 control-label">Current Password</label>
+    <div class="col-md-6">
+		  <input type="password" name="currentpassword" placeholder="Current Password" class="form-control">
+    </div>
+		<span class="col-md-12 description help-block">
 			<span class="failtext"><% if (failReason.currentpassword) { %><%= failReason.currentpassword %><% } else { %>This is not your current password.<% } %> </span>
 			Enter your OpenMRS ID password for verification.
 		</span>
 	</div>
 
-	<div class="field<% if (fail.newpassword) { %> fail<% } %>">
-		<label>New Password</label>
-		<input type="password" name="newpassword" placeholder="New Password">
-		<span class="description">
+	<div class="form-group<% if (fail.newpassword) { %> fail<% } %>">
+		<label for="newpassword" class="col-md-6 control-label">New Password</label>
+    <div class="col-md-6">
+		  <input type="password" name="newpassword" placeholder="New Password" class="form-control">
+    </div>
+		<span class="col-md-12 description help-block">
 			<span class="failtext"><% if (failReason.newpassword) { %><%= failReason.newpassword %><% } else { %>Please enter a valid password.<% } %> </span>
 			Passwords must be at least 8 characters in length.
 		</span>
 	</div>
 
-	<div class="field<% if (fail.confirmpassword) { %> fail<% } %>">
-		<label>Confirm New Password</label>
-		<input type="password" name="confirmpassword" placeholder="Confirm Password">
-		<span class="description">
+	<div class="form-group<% if (fail.confirmpassword) { %> fail<% } %>">
+		<label for="confirmpassword" class="col-md-6 control-label">Confirm New Password</label>
+    <div class="col-md-6">
+		  <input type="password" name="confirmpassword" placeholder="Confirm Password" class="form-control">
+    </div>
+		<span class="col-md-12 description help-block">
 			<span class="failtext"><% if (failReason.confirmpassword) { %><%= failReason.currentpassword %><% } else { %>Passwords do not match.<% } %> </span>
 			Retype your new password to confirm.
 		</span>
 	</div>
 
-	<div class="field">
-		<input class="btn btn-success" type="submit" value="Change Password &#187;">
+	<div class="form-group">
+    <div class="col-md-12">
+		  <input class="btn btn-success pull-right" type="submit" value="Change Password &#187;">
+    </div>
 	</div>
 </form>

--- a/app/system-modules/profile/views/edit-password.ejs
+++ b/app/system-modules/profile/views/edit-password.ejs
@@ -1,7 +1,3 @@
-<% name = 'edit-password' %>
-<% title = 'OpenMRS ID - Your Password' %>
-<% headline = 'Change '+user.displayName+"'s Password" %>
-
 <form action="/password" method="post">
 	<div class="field<% if (fail.currentpassword) { %> fail<% } %>">
 		<label>Current Password</label>

--- a/app/system-modules/profile/views/edit-profile.ejs
+++ b/app/system-modules/profile/views/edit-profile.ejs
@@ -5,29 +5,8 @@
 
 <% style('/resource/stylesheets/profile/profile.css') %>
 
-<form action="/profile" method="post">
 
-    <div class="field noedit">
-        <label>Username</label>
-        <p><%= user.username %></p>
-    </div>
-
-    <div class="field two-up<% if (fail.firstName || fail.lastName ) {
-        %> fail<% } %>">
-        <label>Name</label>
-        <input type="text" name="firstName" placeholder="Given Name" value="<%= (failed) ? values.firstName : user.firstName %>">
-        <input type="text" name="lastName" placeholder="Surname" value="<%= (failed) ? values.lastName : user.lastName %>">
-        <span class="description">
-            <span class="failtext">Both a first and last name are required.</span>
-            Your name identifies you across the OpenMRS Community.
-        </span>
-    </div>
-
-    <div class="field">
-        <input class="btn btn-success" type="submit" value="Update Profile &#187;">
-    </div>
-
-</form>
+<% include edit-basic-details %>
 
 <h2>Email Addresses</h2>
 

--- a/resource/less/form-fields.less
+++ b/resource/less/form-fields.less
@@ -29,7 +29,7 @@
   z-index: 20;
 
   .two-up& {
-    width: 87px !important;
+    width: 120px !important;
     margin-right: 4px;
     float: left !important;
     clear: none;
@@ -104,10 +104,10 @@ input {
     font: 11px sans-serif;
   }
   label {
-    width: 200px;
+    /*width: 200px;
     position: absolute;
     left: -206px;
-    text-align: right;
+    text-align: right;*/
   }
 
   & > .description {
@@ -117,7 +117,7 @@ input {
     width: 300px;
     position: relative;
     z-index: 25;
-    top: 4px;
+    top: 2px;
     margin: 1px 0 0 28px;
     color: #444;
     font-size: 14px;
@@ -146,7 +146,7 @@ input {
 
   p {
     line-height: 27px;
-    font: 11px 'Lucida Grande', 'Segoe UI', 'Helvetica', 'Arial', sans-serif;
+    font-family:'Lucida Grande', 'Segoe UI', 'Helvetica', 'Arial', sans-serif;
     color: #000;
     width: 178px;
     margin: 6px 0 0 8px;

--- a/resource/less/profile/profile.less
+++ b/resource/less/profile/profile.less
@@ -21,3 +21,9 @@
   }
 
 }
+.description.help-block {
+  font-size: 14px;
+}
+.form-horizontal label.control-label {
+  text-align: left;
+}

--- a/resource/scripts/omrsid.js
+++ b/resource/scripts/omrsid.js
@@ -260,7 +260,8 @@ $().ready(function(){
     
     /* toggle Edit Password form */
     $('#editPassword').hide();
-    $('#editPasswordToggle').on('click',function() {
+    $('#editPasswordToggle').on('click',function(e) {
+      e.preventDefault();
       $('#editPassword').slideToggle();
     });
 

--- a/resource/scripts/omrsid.js
+++ b/resource/scripts/omrsid.js
@@ -257,5 +257,11 @@ $().ready(function(){
             .dataset.content = $(this).html();
 
     })
+    
+    /* toggle Edit Password form */
+    $('#editPassword').hide();
+    $('#editPasswordToggle').on('click',function() {
+      $('#editPassword').slideToggle();
+    });
 
 });


### PR DESCRIPTION
GCI Ticket: https://issues.openmrs.org/browse/GCI-41

Since this is only a single widget, the Edit Profile page still looks unorganized. I also separated this widget code into a new file, edit-basic-details.ejs, as suggested on [ticket ID-76](https://issues.openmrs.org/browse/ID-76).
