### PR TITLE
GCI-42: redesign of edit email addresses widget

### DIFF
--- a/app/system-modules/profile/views/edit-email.ejs
+++ b/app/system-modules/profile/views/edit-email.ejs
@@ -1,0 +1,97 @@
+<div class="list-group">
+  <div class="list-group-item">
+
+    <h1>My Email Address(es)</h1>
+    
+    <p>
+        Your email address is not displayed to the public. It is only used for OpenMRS Community Applications and Mailing List communications.
+    </p>
+
+    <ul class="email-selector list-group col-md-12">
+        <%
+        var length = emails.length;
+        emails.forEach(function(m) {
+        %>
+        <li>
+
+            <h3 class="email-address"><%= m.email %>
+                <% if (m.primary) { %>
+                    <small>Primary Email Address</small>
+                <% } %>
+
+                <% if (m.notVerified) { %>
+                    <small>Needs Verification</small>
+                <% } %>
+            </h3>
+          
+            <% if (!m.primary) { %> 
+              <a href="/profile-email/delete/<%= encodeURIComponent(m.email) %>">
+                  <span class="text-danger">
+                      <% if (!m.primary) { %>
+                          Delete
+                      <% } else { %>
+                          Can't Delete Primary Email
+                      <% } %>
+                  </span>
+              </a>
+            <% } else { %>
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox">
+                  Display to other OpenMRS community members
+                </label>
+              </div>
+          <% } %>
+
+            <% if (m.notVerified) { %>
+                <span class="divide">|</span>
+                <a href="/profile-email/resend/<%= m.actionId %>">
+                    Resend Email Verification
+                </a>
+            <% } else { %>
+
+                <% if (!m.primary) { %>
+                    <span class="divide">|</span>
+                    <a href="/profile-email/primary/<%= encodeURIComponent(m.email) %>">
+                        <span class="text-primary">
+                            Make Primary
+                        </span>
+                    </a>
+                <% } %>
+
+            <% } %>
+
+        </li>
+        <hr>
+        <% }) %>
+
+    </ul>
+    
+    <h2><a href="#" id="addEmailToggle">Add Another</a></h2>
+    
+    <% if (length==1) { %>
+      <p>
+        Adding multiple email addresses to your account is recommended, especially if your openmrs.org email address is your primary email address. This allows you to:
+        <ul>
+          <li>Subscribe different email addresses to different mailing lists</li>
+          <li>Reset your password from multiple email addresses</li>
+        </ul>
+      </p>
+    <% } %>
+          
+    <form action="/profile-email/add" method="post" class="form-horizontal" id="addEmail">
+      <div class="form-group">
+        <label for="newEmail" class="control-label col-sm-4">New Email</label>
+        <div class="col-sm-8">
+          <input class="form-control" type="text" name="newEmail">
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-12">
+          <input type="submit" class="btn btn-success pull-right" value="Add">
+        </div>
+      </div>
+    </form>
+
+  </div>
+</div>

--- a/app/system-modules/profile/views/edit-email.ejs
+++ b/app/system-modules/profile/views/edit-email.ejs
@@ -34,14 +34,7 @@
                       <% } %>
                   </span>
               </a>
-            <% } else { %>
-              <div class="checkbox">
-                <label>
-                  <input type="checkbox">
-                  Display to other OpenMRS community members
-                </label>
-              </div>
-          <% } %>
+            <% } %>
 
             <% if (m.notVerified) { %>
                 <span class="divide">|</span>
@@ -67,7 +60,7 @@
 
     </ul>
     
-    <h2><a href="#" id="addEmailToggle">Add Another</a></h2>
+    <h2><a href="#" id="addEmailToggle">Add Another...</a></h2>
     
     <% if (length==1) { %>
       <p>

--- a/app/system-modules/profile/views/edit-profile.ejs
+++ b/app/system-modules/profile/views/edit-profile.ejs
@@ -5,117 +5,36 @@
 
 <% style('/resource/stylesheets/profile/profile.css') %>
 
-<form action="/profile" method="post">
+<div class="col-md-6">
 
-    <div class="field noedit">
-        <label>Username</label>
-        <p><%= user.username %></p>
-    </div>
+  <form action="/profile" method="post">
 
-    <div class="field two-up<% if (fail.firstName || fail.lastName ) {
-        %> fail<% } %>">
-        <label>Name</label>
-        <input type="text" name="firstName" placeholder="Given Name" value="<%= (failed) ? values.firstName : user.firstName %>">
-        <input type="text" name="lastName" placeholder="Surname" value="<%= (failed) ? values.lastName : user.lastName %>">
-        <span class="description">
-            <span class="failtext">Both a first and last name are required.</span>
-            Your name identifies you across the OpenMRS Community.
-        </span>
-    </div>
+      <div class="field noedit">
+          <label>Username</label>
+          <p><%= user.username %></p>
+      </div>
 
-    <div class="field">
-        <input class="btn btn-success" type="submit" value="Update Profile &#187;">
-    </div>
+      <div class="field two-up<% if (fail.firstName || fail.lastName ) {
+          %> fail<% } %>">
+          <label>Name</label>
+          <input type="text" name="firstName" placeholder="Given Name" value="<%= (failed) ? values.firstName : user.firstName %>">
+          <input type="text" name="lastName" placeholder="Surname" value="<%= (failed) ? values.lastName : user.lastName %>">
+          <span class="description">
+              <span class="failtext">Both a first and last name are required.</span>
+              Your name identifies you across the OpenMRS Community.
+          </span>
+      </div>
 
-</form>
+      <div class="field">
+          <input class="btn btn-success" type="submit" value="Update Profile &#187;">
+      </div>
 
-<h2>Email Addresses</h2>
-
-<p>
-    OpenMRS Community Applications and Mailing Lists contact you via your
-    email address. Your email address is not shown to the public, but can
-    be optionally shown to other OpenMRS Community members.
-</p>
-<p>
-    Adding multiple email addresses allows you to use them on different 
-    mailing lists, and allows you to reset your account password from multiple
-    email addresses. If you have an <b>@openmrs.org</b> email address, it's a
-    good idea to add an additional email.
-</p>
-
-<div class="row">
-<ul class="email-selector list-group col-md-8">
-    <%
-    var length = emails.length;
-    emails.forEach(function(m) {
-    %>
-    <li class="list-group-item">
-
-        <h3 class="list-group-item-heading">
-            <span class="email-address"><%= m.email %></span>
-            <% if (m.primary) { %>
-                <span class="badge badge-primary">Primary</span>
-            <% } %>
-
-            <% if (m.notVerified) { %>
-                <span class="badge">Needs Verification</span>
-            <% } %>
-        </h3>
-
-        <a class="btn btn-default <% if (m.primary) { %>disabled<% } %>"
-        href="/profile-email/delete/<%= encodeURIComponent(m.email) %>">
-            <span class="text-danger">
-                <span class="glyphicon glyphicon-remove"></span>
-                <% if (!m.primary) { %>
-                    Delete
-                <% } else { %>
-                    Can't Delete Primary Email
-                <% } %>
-            </span>
-        </a>
-
-        
-        <% if (m.notVerified) { %>
-            <a class="btn btn-default"
-            href="/profile-email/resend/<%= m.actionId %>">
-                <span class="glyphicon glyphicon-repeat"></span>
-                Resend Email Verification
-            </a>
-        <% } else { %>
-
-            <% if (!m.primary) { %>
-                <a class="btn btn-default"
-                href="/profile-email/primary/<%= encodeURIComponent(m.email) %>">
-                    <span class="text-primary">
-                        <span class="glyphicon glyphicon-asterisk"></span>
-                        Make Primary
-                    </span>
-                </a>
-            <% } %>
-
-        <% } %>
-
-    </li>
-    <% }) %>
-
-</ul>
+  </form>
+ 
 </div>
-<div class="row">
-<ul class="list-group col-md-8">
 
-    <li class="list-group-item add-email-address">
-
-        <form class="form" action="/profile-email/add" method="post">
-            <div class="form-group">
-                <label>Add an Email Address</label>
-                <input class="form-control" type="text" name="newEmail" 
-                placeholder="Email Address">
-            </div>
-
-            <div class="form-group">
-                <input type="submit" class="btn btn-success" value="Add &#187;">
-
-        </form>
-    </li>
-<ul>
+<div class="col-md-6">
+  
+  <% include edit-email %>
+  
 </div>

--- a/resource/less/profile/profile.less
+++ b/resource/less/profile/profile.less
@@ -1,23 +1,21 @@
 @import "../colors";
 
+.list-group-item h1 {
+  margin-top: 10px;
+}
+
 .email-selector {
-
-  .badge {
-    position: relative;
-    top: -.083333333em;
-
-    &.badge-primary {
-      background-color: @brand-primary;
-    }
+  list-style: none;
+  
+  &.list-group {
+    margin-bottom: 0;
   }
+}
 
-  .add-email-address {
-    // border-top-width: 2px;
-    // border-top-color: #bbb;
-  }
+.form-horizontal label.control-label {
+  text-align: left;
+}
 
-  .btn.disabled {
-    cursor: not-allowed;
-  }
-
+.divide {
+  margin: 0 5px;
 }

--- a/resource/scripts/omrsid.js
+++ b/resource/scripts/omrsid.js
@@ -257,5 +257,12 @@ $().ready(function(){
             .dataset.content = $(this).html();
 
     })
+    
+    /* toggle Edit Password form */
+    $('#addEmail').hide();
+    $('#addEmailToggle').on('click',function(e) {
+      e.preventDefault();
+      $('#addEmail').slideToggle();
+    });
 
 });

--- a/resource/scripts/omrsid.js
+++ b/resource/scripts/omrsid.js
@@ -262,7 +262,8 @@ $().ready(function(){
     $('#addEmail').hide();
     $('#addEmailToggle').on('click',function(e) {
       e.preventDefault();
-      $('#addEmail').slideToggle();
+      $('#addEmail').toggle();
+      $('#addEmail input[name=newEmail]').focus();
     });
 
 });


### PR DESCRIPTION
Ticket: https://issues.openmrs.org/browse/GCI-42
Melange task: http://www.google-melange.com/gci/task/view/google/gci2014/5270481909317632

I moved the widget code into a new file, edit-email.ejs. Also, I wasn't sure if the "Add Another" link was supposed to toggle the email input field, but I implemented it similar to the password-edit toggle in my [previous PR](https://github.com/openmrs/openmrs-contrib-id/pull/43).
