### PR TITLE
GCI-38: Revamp edit account page

### DIFF
--- a/app/system-modules/profile/views/edit-profile.ejs
+++ b/app/system-modules/profile/views/edit-profile.ejs
@@ -3,119 +3,29 @@
 <% headline = user.displayName+"'s Profile" %>
 <% sidebar = ['sidebar/editprofile-avatar'] %>
 
+<% include widgets/newuser %>
+
 <% style('/resource/stylesheets/profile/profile.css') %>
 
-<form action="/profile" method="post">
-
-    <div class="field noedit">
-        <label>Username</label>
-        <p><%= user.username %></p>
-    </div>
-
-    <div class="field two-up<% if (fail.firstName || fail.lastName ) {
-        %> fail<% } %>">
-        <label>Name</label>
-        <input type="text" name="firstName" placeholder="Given Name" value="<%= (failed) ? values.firstName : user.firstName %>">
-        <input type="text" name="lastName" placeholder="Surname" value="<%= (failed) ? values.lastName : user.lastName %>">
-        <span class="description">
-            <span class="failtext">Both a first and last name are required.</span>
-            Your name identifies you across the OpenMRS Community.
-        </span>
-    </div>
-
-    <div class="field">
-        <input class="btn btn-success" type="submit" value="Update Profile &#187;">
-    </div>
-
-</form>
-
-<h2>Email Addresses</h2>
-
-<p>
-    OpenMRS Community Applications and Mailing Lists contact you via your
-    email address. Your email address is not shown to the public, but can
-    be optionally shown to other OpenMRS Community members.
-</p>
-<p>
-    Adding multiple email addresses allows you to use them on different 
-    mailing lists, and allows you to reset your account password from multiple
-    email addresses. If you have an <b>@openmrs.org</b> email address, it's a
-    good idea to add an additional email.
-</p>
-
-<div class="row">
-<ul class="email-selector list-group col-md-8">
-    <%
-    var length = emails.length;
-    emails.forEach(function(m) {
-    %>
-    <li class="list-group-item">
-
-        <h3 class="list-group-item-heading">
-            <span class="email-address"><%= m.email %></span>
-            <% if (m.primary) { %>
-                <span class="badge badge-primary">Primary</span>
-            <% } %>
-
-            <% if (m.notVerified) { %>
-                <span class="badge">Needs Verification</span>
-            <% } %>
-        </h3>
-
-        <a class="btn btn-default <% if (m.primary) { %>disabled<% } %>"
-        href="/profile-email/delete/<%= encodeURIComponent(m.email) %>">
-            <span class="text-danger">
-                <span class="glyphicon glyphicon-remove"></span>
-                <% if (!m.primary) { %>
-                    Delete
-                <% } else { %>
-                    Can't Delete Primary Email
-                <% } %>
-            </span>
-        </a>
-
-        
-        <% if (m.notVerified) { %>
-            <a class="btn btn-default"
-            href="/profile-email/resend/<%= m.actionId %>">
-                <span class="glyphicon glyphicon-repeat"></span>
-                Resend Email Verification
-            </a>
-        <% } else { %>
-
-            <% if (!m.primary) { %>
-                <a class="btn btn-default"
-                href="/profile-email/primary/<%= encodeURIComponent(m.email) %>">
-                    <span class="text-primary">
-                        <span class="glyphicon glyphicon-asterisk"></span>
-                        Make Primary
-                    </span>
-                </a>
-            <% } %>
-
-        <% } %>
-
-    </li>
-    <% }) %>
-
-</ul>
+<div class="col-sm-6">
+  <div class="panel panel-default" style="padding:10px; padding-top:0px">
+    <% include widgets/profile-info %>
+  </div>
+  <div class="panel panel-default" style="padding:10px">
+    <% include widgets/demo %>
+  </div>
+  <div class="panel panel-default" style="padding:10px">
+    <% include widgets/demo %>
+  </div>
 </div>
-<div class="row">
-<ul class="list-group col-md-8">
-
-    <li class="list-group-item add-email-address">
-
-        <form class="form" action="/profile-email/add" method="post">
-            <div class="form-group">
-                <label>Add an Email Address</label>
-                <input class="form-control" type="text" name="newEmail" 
-                placeholder="Email Address">
-            </div>
-
-            <div class="form-group">
-                <input type="submit" class="btn btn-success" value="Add &#187;">
-
-        </form>
-    </li>
-<ul>
+<div class="col-sm-6">
+  <div class="panel panel-default" style="padding:10px">
+    <% include widgets/demo %>
+  </div>
+  <div class="panel panel-default" style="padding:10px">
+    <% include widgets/demo %>
+  </div>
+  <div class="panel panel-default" style="padding:10px">
+    <% include widgets/demo %>
+  </div>
 </div>

--- a/app/system-modules/profile/views/widgets/demo.ejs
+++ b/app/system-modules/profile/views/widgets/demo.ejs
@@ -1,0 +1,1 @@
+<p>This here is a bunch of text. Yay for text!</p>

--- a/app/system-modules/profile/views/widgets/newuser.ejs
+++ b/app/system-modules/profile/views/widgets/newuser.ejs
@@ -1,0 +1,22 @@
+<div class="panel panel-primary">
+  <div class="panel-body">
+
+    <div class="col-sm-5" style="padding: 15px">
+      <strong>Welcome to the OpenMRS Community!</strong>
+      <br />
+      <br />
+      <p>We're so glad you've joined us. Here are 3 easy ways to get started and let others know who you are.</p>
+    </div>
+    <div class="col-sm-offset-5" style="padding:15px">
+      <ol>
+        <li><a href="#">Subscribe to a Mailing List</a> to stay connected to the community.</li>
+        <li><a href="#">Edit your Wiki Profile</a> so we can learn more about you.</li>
+        <li><a href="#">Create your own Personal Space</a> on the Wiki.</li>
+      </ol>
+    </div>
+    <div style="float:right">
+      <input type="submit" class="btn btn-primary new-user-done" value="Thanks, I've done these." style="margin-right:10px">
+      <input type="submit" class="btn btn-default new-user-remind-later" value="Remind me later">
+    </div>
+  </div>
+</div>

--- a/app/system-modules/profile/views/widgets/profile-info.ejs
+++ b/app/system-modules/profile/views/widgets/profile-info.ejs
@@ -1,0 +1,20 @@
+<form action="/profile" method="post">
+
+    <h3><%= user.username %> <small>username</small></h3>
+
+    <h4>Name</h4>
+    <div class="field two-up<% if (fail.firstName || fail.lastName ) {
+        %> fail<% } %>">
+        <input type="text" name="firstName" placeholder="Given Name" value="<%= (failed) ? values.firstName : user.firstName %>">
+        <input type="text" name="lastName" placeholder="Surname" value="<%= (failed) ? values.lastName : user.lastName %>">
+        <span class="description">
+            <span class="failtext">Both a first and last name are required.</span>
+            Your name identifies you across the OpenMRS Community.
+        </span>
+    </div>
+
+    <div class="field">
+        <input class="btn btn-success" type="submit" value="Save Changes" style="float:right">
+    </div>
+
+</form>


### PR DESCRIPTION
My work on [GCI-38](https://issues.openmrs.org/browse/GCI-38) / [ID-75](https://issues.openmrs.org/browse/ID-75).

I implemented the new layout and new user guidance box. The edit name widget works, the rest are simple template widgets to test the layout.

GCI Melange task: http://www.google-melange.com/gci/task/view/google/gci2014/5000010773037056
