### PR TITLE
[GCI-41] Redesign account details widget

### DIFF
--- a/app/system-modules/profile/lib/routes/password.js
+++ b/app/system-modules/profile/lib/routes/password.js
@@ -55,6 +55,6 @@ app.post('/password', mid.forceLogin, profileMid.passwordValidator,
 
     req.flash('success', 'Password changed.');
     req.session.user = user;
-    res.redirect('/');
+    res.redirect('/profile');
   });
 });

--- a/app/system-modules/profile/views/edit-basic-details.ejs
+++ b/app/system-modules/profile/views/edit-basic-details.ejs
@@ -1,0 +1,35 @@
+<h1 class="username">
+    <%= user.username %>
+    <small>username</small>
+</h1>
+
+<form action="/profile" method="post">
+    <div class="form-group two-up<% if (fail.firstName || fail.lastName ) { %> fail has-error<% } %>">
+        <label class="control-label" >Name</label>
+        <input type="text" name="firstName" placeholder="Given Name" value="<%= (failed) ? values.firstName : user.firstName %>">
+        <input type="text" name="lastName" placeholder="Surname" value="<%= (failed) ? values.lastName : user.lastName %>">
+        <div class="description">
+            <span class="failtext help-block">Both a first and last name are required.</span>
+            Your name identifies you across the OpenMRS Community.
+        </div>
+    </div>
+
+    <div class="form-group submit-right">
+        <input class="btn btn-success" type="submit" value="Update Profile &#187;">
+    </div>
+
+</form>
+
+<hr />
+
+<h2>Your profile picture</h2>
+<img src="https://wiki.openmrs.org/rest/cas/1.0/avatar/server/<%= mailHash %>?s=51" alt="<%= user.displayName %>" class="user-image">
+<p>
+    Profile pictures are managed along with your profile on the OpenMRS Wiki.
+    <a href="https://wiki.openmrs.org/users/editmyprofilepicture.action" target="_blank">Edit your profile picture on the Wiki &raquo;</a>
+</p>
+
+<hr />
+
+<h2><a href="#change-password-form" id="change-password-link">Need to change your password?</a></h2>
+<% include edit-password %>

--- a/app/system-modules/profile/views/edit-password.ejs
+++ b/app/system-modules/profile/views/edit-password.ejs
@@ -1,36 +1,38 @@
-<% name = 'edit-password' %>
-<% title = 'OpenMRS ID - Your Password' %>
-<% headline = 'Change '+user.displayName+"'s Password" %>
+<form action="/password" method="post" class="form-horizontal" id="change-password-form">
+    <div class="form-group<% if (fail.currentpassword) { %> fail has-error<% } %>">
+        <label class="col-sm-5 control-label">Current Password</label>
+        <div class="col-sm-7">
+            <input type="password" name="currentpassword" placeholder="Current Password" class="form-control">
+            <span class="description">
+                <span class="failtext help-block"><% if (failReason.currentpassword) { %><%= failReason.currentpassword %><% } else { %>This is not your current password.<% } %> </span>
+                Enter your OpenMRS ID password for verification.
+            </span>
+        </div>
+    </div>
 
-<form action="/password" method="post">
-	<div class="field<% if (fail.currentpassword) { %> fail<% } %>">
-		<label>Current Password</label>
-		<input type="password" name="currentpassword" placeholder="Current Password">
-		<span class="description">
-			<span class="failtext"><% if (failReason.currentpassword) { %><%= failReason.currentpassword %><% } else { %>This is not your current password.<% } %> </span>
-			Enter your OpenMRS ID password for verification.
-		</span>
-	</div>
+    <div class="form-group<% if (fail.newpassword) { %> fail has-error<% } %>">
+        <label class="col-sm-5 control-label">New Password</label>
+        <div class="col-sm-7">
+            <input type="password" name="newpassword" placeholder="New Password" class="form-control">
+            <span class="description">
+                <span class="failtext help-block"><% if (failReason.newpassword) { %><%= failReason.newpassword %><% } else { %>Please enter a valid password.<% } %> </span>
+                Passwords must be at least 8 characters in length.
+            </span>
+        </div>
+    </div>
 
-	<div class="field<% if (fail.newpassword) { %> fail<% } %>">
-		<label>New Password</label>
-		<input type="password" name="newpassword" placeholder="New Password">
-		<span class="description">
-			<span class="failtext"><% if (failReason.newpassword) { %><%= failReason.newpassword %><% } else { %>Please enter a valid password.<% } %> </span>
-			Passwords must be at least 8 characters in length.
-		</span>
-	</div>
+    <div class="form-group<% if (fail.confirmpassword) { %> fail has-error<% } %>">
+        <label class="col-sm-5 control-label">Confirm New Password</label>
+        <div class="col-sm-7">
+            <input type="password" name="confirmpassword" placeholder="Confirm Password" class="form-control">
+            <span class="description">
+                <span class="failtext"><% if (failReason.confirmpassword) { %><%= failReason.currentpassword %><% } else { %>Passwords do not match.<% } %> </span>
+                Retype your new password to confirm.
+            </span>
+        </div>
+    </div>
 
-	<div class="field<% if (fail.confirmpassword) { %> fail<% } %>">
-		<label>Confirm New Password</label>
-		<input type="password" name="confirmpassword" placeholder="Confirm Password">
-		<span class="description">
-			<span class="failtext"><% if (failReason.confirmpassword) { %><%= failReason.currentpassword %><% } else { %>Passwords do not match.<% } %> </span>
-			Retype your new password to confirm.
-		</span>
-	</div>
-
-	<div class="field">
-		<input class="btn btn-success" type="submit" value="Change Password &#187;">
-	</div>
+    <div class="form-group submit-right">
+        <input class="btn btn-success" type="submit" value="Change Password &#187;">
+    </div>
 </form>

--- a/app/system-modules/profile/views/edit-profile.ejs
+++ b/app/system-modules/profile/views/edit-profile.ejs
@@ -1,33 +1,14 @@
 <% name = 'edit-profile' %>
 <% title = 'OpenMRS ID - Your Profile' %>
 <% headline = user.displayName+"'s Profile" %>
-<% sidebar = ['sidebar/editprofile-avatar'] %>
 
 <% style('/resource/stylesheets/profile/profile.css') %>
-
-<form action="/profile" method="post">
-
-    <div class="field noedit">
-        <label>Username</label>
-        <p><%= user.username %></p>
+<div class="row">
+    <div class="col-md-6 col-sm-12">
+        <% include edit-basic-details %>
     </div>
 
-    <div class="field two-up<% if (fail.firstName || fail.lastName ) {
-        %> fail<% } %>">
-        <label>Name</label>
-        <input type="text" name="firstName" placeholder="Given Name" value="<%= (failed) ? values.firstName : user.firstName %>">
-        <input type="text" name="lastName" placeholder="Surname" value="<%= (failed) ? values.lastName : user.lastName %>">
-        <span class="description">
-            <span class="failtext">Both a first and last name are required.</span>
-            Your name identifies you across the OpenMRS Community.
-        </span>
-    </div>
-
-    <div class="field">
-        <input class="btn btn-success" type="submit" value="Update Profile &#187;">
-    </div>
-
-</form>
+<div class="col-md-6 col-sm-12">
 
 <h2>Email Addresses</h2>
 
@@ -37,7 +18,7 @@
     be optionally shown to other OpenMRS Community members.
 </p>
 <p>
-    Adding multiple email addresses allows you to use them on different 
+    Adding multiple email addresses allows you to use them on different
     mailing lists, and allows you to reset your account password from multiple
     email addresses. If you have an <b>@openmrs.org</b> email address, it's a
     good idea to add an additional email.
@@ -74,7 +55,7 @@
             </span>
         </a>
 
-        
+
         <% if (m.notVerified) { %>
             <a class="btn btn-default"
             href="/profile-email/resend/<%= m.actionId %>">
@@ -108,7 +89,7 @@
         <form class="form" action="/profile-email/add" method="post">
             <div class="form-group">
                 <label>Add an Email Address</label>
-                <input class="form-control" type="text" name="newEmail" 
+                <input class="form-control" type="text" name="newEmail"
                 placeholder="Email Address">
             </div>
 
@@ -118,4 +99,7 @@
         </form>
     </li>
 <ul>
+</div>
+
+</div>
 </div>

--- a/resource/less/form-fields.less
+++ b/resource/less/form-fields.less
@@ -231,3 +231,10 @@ input {
   width: 310px;
   font-style: italic;
 }
+
+.submit-right {
+  overflow:hidden;
+  .btn-success {
+    float: right;
+  }
+}

--- a/resource/less/profile/profile.less
+++ b/resource/less/profile/profile.less
@@ -21,3 +21,12 @@
   }
 
 }
+
+#change-password-form {
+  display: none;
+}
+
+.user-image {
+  float:left;
+  margin-right: 4px;
+}

--- a/resource/scripts/omrsid.js
+++ b/resource/scripts/omrsid.js
@@ -258,4 +258,13 @@ $().ready(function(){
 
     })
 
+    $('#change-password-link').on('click', function(event) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        var changePassword = $('#change-password-form');
+        changePassword.toggle();
+        $('input[name=currentpassword]', changePassword).focus();
+    });
+
 });

--- a/views/sidebar/editprofile-avatar.ejs
+++ b/views/sidebar/editprofile-avatar.ejs
@@ -1,2 +1,0 @@
-<h2>Your profile picture</h2>
-<p>Profile pictures are managed along with your profile on the OpenMRS Wiki. Head over to Confluence to <a href="https://wiki.openmrs.org/users/viewmyprofile.action" target="_blank">edit your Wiki profile</a> or <a href="https://wiki.openmrs.org/users/editmyprofilepicture.action" target="_blank">change your profile picture</a>.</p>


### PR DESCRIPTION
[For this issue](https://issues.openmrs.org/browse/GCI-41) and [this task](https://www.google-melange.com/gci/task/view/google/gci2014/4804252539027456)

This implements the basic accounts details. 

However the password section redirects to `/password` on failed verification so I have left in the password page and the [associated navigation link](https://github.com/SquidDev-GCI/openmrs-contrib-id/blob/master/app/user-nav.js#L39-L46).
