### PR TITLE
ID-87

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ test/conf.js
 *.sublime-*
 .ldaprc
 *.todo
+*~
 
 # OS generated files #
 ######################

--- a/app/utils.js
+++ b/app/utils.js
@@ -13,7 +13,7 @@ exports.getSSHA = function (cleartext, salt) {
   var sum = crypto.createHash('sha1');
   sum.update(cleartext);
   sum.update(salt);
-  var digest = sum.digest();
+  var digest = sum.digest('binary');
   var ret = '{SSHA}' +  new Buffer(digest+salt,'binary').toString('base64');
   return ret;
 };


### PR DESCRIPTION
In 0.8.x and 0.10.x, the `hash.digest()' will return different results if there is no encoding is provided. 

In earlier works, I used the 'default' way. However, that will lead potential errors. As in 0.10.x the result will be a buffer and later be auto-casted as a utf8 string while the result in 0.8.x will be a binary string.

See 0.8.x [docs](http://nodejs.org/docs/v0.8.3/api/crypto.html#crypto_hash_digest_encoding), and 0.10.x [docs](http://nodejs.org/docs/v0.10.30/api/crypto.html#crypto_hash_digest_encoding).
