### PR TITLE
changed ldap.isDisabled logic for ID-82

### DIFF
--- a/app/conf.example.js
+++ b/app/conf.example.js
@@ -21,7 +21,7 @@ module.exports = {
   },
   "ldap": {
     // LDAP Settings
-
+    "enabled": true,
     "server": {
       "uri": "ldap://localhost",
       "baseDn": "ou=systemacct,dc=example",

--- a/app/ldap.js
+++ b/app/ldap.js
@@ -566,7 +566,7 @@ exports.addGroup = function (group, cb) {
 
 // check if LDAP is disabled
 exports.isDisabled = function() {
-  return (!process.env.NODE_ENV || 'development' === process.env.NODE_ENV) && 'true' !== process.env.LDAP;
+  return false === conf.ldap.enabled;
 };
 
 // tests

--- a/app/ldap.js
+++ b/app/ldap.js
@@ -566,7 +566,7 @@ exports.addGroup = function (group, cb) {
 
 // check if LDAP is disabled
 exports.isDisabled = function() {
-  return false === conf.ldap.enabled;
+  return false === require('./conf').ldap.enabled;
 };
 
 // tests

--- a/installing-openmrsid.md
+++ b/installing-openmrsid.md
@@ -110,6 +110,10 @@ Installing OpenMRS ID
 	3. Mysql/MongoDB database name and credentials
 	4. Postfix mail sending credentials and port
 	5. reCAPTCHA keys (if you have them—they are required for signup)
+
+	If you don't need LDAP, and don't want to configure it, you may disable LDAP in config.
+
+    Change "ldap.enabled" to ```false```.
  
 	In addition, remove the items in the `user-modules` array. Modules need to be manually downloaded and placed in the `app/user-modules` directory.	
 	
@@ -118,12 +122,6 @@ Installing OpenMRS ID
 	```
 	node app/app
 	```
-
-    Note, that LDAP is disabled by default in development mode. For using LDAP in development, set LDAP=true before starting:
-
-    ```
-    LDAP=true node app/app
-    ```
 ### Addtional Notes
 
 1. For development purpose, it's not necessary to install and play the Postfix mailer. You may take a look of the [Mailcatcher][5], which is a ruby application that catches all the emails sent from local server.

--- a/test/ldap.js
+++ b/test/ldap.js
@@ -1,0 +1,54 @@
+var fs = require('fs');
+var expect = require('chai').expect;
+var util = require('util');
+var path = require('path');
+var ldap = require('../app/ldap');
+
+describe('LDAP', function() {
+  // clean module cache before each test
+  var cleanCache = function(filePath){
+    delete require.cache[path.resolve(filePath)];
+  };
+
+  var originalConf;
+  // test config
+  var testConf = 'module.exports = {' +
+    '"ldap": {' +
+      '"enabled": %s' +
+    '}' +
+  '}';
+  // LDAP config placed here
+  var configPath = 'app/conf.js';
+  before(function(done) {
+    // if file exists, save config data
+    if (fs.existsSync(configPath)) originalConf = fs.readFileSync(configPath, 'utf8');
+    done();
+  });
+  after(function(done) {
+    // restore data
+    if (originalConf) fs.writeFileSync(configPath, originalConf, 'utf8');
+    done();
+  });
+  it('ldap should be enabled when missing "ldap.enabled" param (by default)', function(done) {
+    var textVal = 'undefined';
+    fs.writeFileSync(configPath, util.format(testConf, textVal), 'utf8');
+    cleanCache(configPath);
+    expect(ldap.isDisabled()).to.be.false;
+    done()
+  });
+
+  it('ldap should be enabled when "ldap.enabled" equal true', function(done) {
+    var textVal = 'true';
+    fs.writeFileSync(configPath, util.format(testConf, textVal), 'utf8');
+    cleanCache(configPath);
+    expect(ldap.isDisabled()).to.be.false;
+    done();
+  });
+  it('ldap should be disabled when "ldap.enabled" equal false' , function (done) {
+    var textVal = 'false';
+    fs.writeFileSync(configPath, util.format(testConf, textVal), 'utf8');
+    cleanCache(configPath);
+    expect(ldap.isDisabled()).to.be.true;
+    done();
+  });
+});

--- a/test/user.js
+++ b/test/user.js
@@ -2,8 +2,6 @@
 var _ = require('lodash');
 var expect = require('chai').expect;
 var async = require('async');
-var fs = require('fs');
-var conf = require('./conf');
 
 var User = require('../app/model/user');
 var Group = require('../app/model/group');

--- a/test/user.js
+++ b/test/user.js
@@ -431,7 +431,7 @@ describe('User', function() {
       ]);
     });
   });
-
+    /*
   describe('LDAP test', function() {
     var env;
     before(function(done) {
@@ -474,7 +474,7 @@ describe('User', function() {
       expect(ldap.isDisabled()).to.be.true;
       done();
     });
-  });
+  }); */
 
   /// TODO test with LDAP
   // describe('sync with LDAP', function() {

--- a/test/user.js
+++ b/test/user.js
@@ -2,10 +2,11 @@
 var _ = require('lodash');
 var expect = require('chai').expect;
 var async = require('async');
+var fs = require('fs');
+var conf = require('./conf');
 
 var User = require('../app/model/user');
 var Group = require('../app/model/group');
-var ldap = require('../app/ldap');
 
 // data for testing purposes
 var VALID_EMAIL1 = 'foo@bar.com';
@@ -58,7 +59,6 @@ var GROUP1 = {
 };
 
 var DUP_ERROR_CODE = 11000;
-
 
 describe('User', function() {
   before(function (done) {
@@ -303,6 +303,8 @@ describe('User', function() {
     });
   });
 
+
+
   /// Some API tests
   describe('finders', function() {
     var userx;
@@ -431,50 +433,6 @@ describe('User', function() {
       ]);
     });
   });
-    /*
-  describe('LDAP test', function() {
-    var env;
-    before(function(done) {
-      // save NODE_ENV value if it was set before
-      if (process.env.NODE_ENV) env = process.env.NODE_ENV;
-      done();
-    });
-    after(function(done) {
-      // restore NODE_ENV value
-      if (env) process.env.NODE_ENV = env;
-      done();
-    });
-    // clear variables before each test
-    beforeEach(function(done) {
-        delete process.env.NODE_ENV;
-        delete process.env.LDAP;
-      done();
-    });
-    it('ldap should be disabled by default', function(done) {
-      expect(ldap.isDisabled()).to.be.true;
-      done()
-    });
-    it('ldap should be enabled for production', function(done) {
-      process.env.NODE_ENV = 'production';
-      expect(ldap.isDisabled()).to.be.false;
-      done();
-    });
-    it('ldap should be enabled for development when variable LDAP set to "true"', function (done) {
-      process.env.LDAP = 'true';
-      expect(ldap.isDisabled()).to.be.false;
-        done();
-    });
-    it('ldap should be disabled for development when variable LDAP set to "false"', function (done) {
-      process.env.LDAP = 'false';
-      expect(ldap.isDisabled()).to.be.true;
-      done();
-    });
-    it('ldap should be disabled for development when variable LDAP set to any value except "true"', function(done) {
-      process.env.LDAP = '123';
-      expect(ldap.isDisabled()).to.be.true;
-      done();
-    });
-  }); */
 
   /// TODO test with LDAP
   // describe('sync with LDAP', function() {


### PR DESCRIPTION
I've been changed ldap.isDisabled method logic. Now for disabling ldap user can set `ldap.enbled` to false.
`conf.example.js` was updated with option `ldap.enabled`
also Readme for installing was updated.
