### PR TITLE
Added option to LDAP to auto-reconnect and also to fail fast when con…

### DIFF
--- a/app/ldap.js
+++ b/app/ldap.js
@@ -36,12 +36,12 @@ const client = ldap.createClient({
 	maxConnections: 10,
 	bindDN: systemDN,
 	bindCredentials: bindCredentials,
-  queueDisable: true, //fail fast when connections times out. https://github.com/mcavage/node-ldapjs/issues/328
-  reconnect: { // tries to reconnect if LDAP server is down. https://github.com/mcavage/node-ldapjs/issues/403
-        initialDelay: 100,
-        maxDelay: 500,
-        failAfter: 10
-    }
+        queueDisable: true, //fail fast when connections times out. https://github.com/mcavage/node-ldapjs/issues/328
+        reconnect: { // tries to reconnect if LDAP server is down. https://github.com/mcavage/node-ldapjs/issues/403
+            initialDelay: 100,
+            maxDelay: 500,
+            failAfter: 10
+        }
 	// timeout: ,
 	// connectTimeout: ,
 });

--- a/app/ldap.js
+++ b/app/ldap.js
@@ -36,6 +36,12 @@ const client = ldap.createClient({
 	maxConnections: 10,
 	bindDN: systemDN,
 	bindCredentials: bindCredentials,
+  queueDisable: true, //fail fast when connections times out. https://github.com/mcavage/node-ldapjs/issues/328
+  reconnect: { // tries to reconnect if LDAP server is down. https://github.com/mcavage/node-ldapjs/issues/403
+        initialDelay: 100,
+        maxDelay: 500,
+        failAfter: 10
+    }
 	// timeout: ,
 	// connectTimeout: ,
 });


### PR DESCRIPTION
…nection times out.

These two options are undocumented, but they do exist. I added as comments the issues where they are mentioned.

If you want to test them, just start your application in development mode and restart the OpenLDAP docker container. It now will work as usual, when before the request would hang. This was done accomplished by adding the option `reconnect`.

The option `queueDisabled` is to make sure the request does not hang if the LDAP connection is down for some reason. However, the error displayed for the user is a generic 500 error. It would be nice to actually show a meaningful message at this point such as "Fail to create user. Try again in 5 minutes or create an issue at <link to helpdeks>". 